### PR TITLE
feat(parser): extern function

### DIFF
--- a/editor/cb.vim
+++ b/editor/cb.vim
@@ -10,7 +10,7 @@ syn keyword aKeyword if else
 syn keyword aKeyword true false
 syn keyword aKeyword or and let in const
 syn keyword aKeyword fn struct enum union type
-syn keyword aKeyword return
+syn keyword aKeyword return extern
 
 " syn keyword aFunction println print
 

--- a/examples/extern.cb
+++ b/examples/extern.cb
@@ -1,0 +1,10 @@
+ extern C fn initWindow(s33, s32) void;
+ extern C fn beginDrawing() void;
+ extern C fn drawText(*u8, s32, s32, s32, u32) void;
+ extern C fn closeWindow() void;
+
+ pub fn main() void {
+     initWindow(800, 600);
+     beginDrawing();
+     closeWindow();
+ }

--- a/src/stage/ir_builder/mod.rs
+++ b/src/stage/ir_builder/mod.rs
@@ -87,6 +87,7 @@ impl Stage<(SymbolTable, Vec<Item>), Result<Module>> for IRBuilder {
                 Item::Function(function) => self.build_function(function, &mut mb),
                 Item::Type(_) => {}
                 Item::Use(u) => self.build_use(u),
+                Item::ExternFunction(extern_function) => todo!(),
             }
         }
         Ok(mb.build())

--- a/src/stage/lexer/testdata/output/cflat__stage__lexer__tests__extern_function.snap
+++ b/src/stage/lexer/testdata/output/cflat__stage__lexer__tests__extern_function.snap
@@ -1,0 +1,82 @@
+---
+source: src/stage/lexer/tests.rs
+expression: snapshot_lexing(contents)
+---
+ extern C fn initWindow(s33, s32) void;
+ ^^^^^^ Token { kind: Keyword(Extern), lexeme: "extern", span: 1..7 }
+        ^ Token { kind: Identifier, lexeme: "C", span: 8..9 }
+          ^^ Token { kind: Keyword(Fn), lexeme: "fn", span: 10..12 }
+             ^^^^^^^^^^ Token { kind: Identifier, lexeme: "initWindow", span: 13..23 }
+                       ^ Token { kind: LeftParen, lexeme: "(", span: 23..24 }
+                        ^^^ Token { kind: Identifier, lexeme: "s33", span: 24..27 }
+                           ^ Token { kind: Comma, lexeme: ",", span: 27..28 }
+                             ^^^ Token { kind: Identifier, lexeme: "s32", span: 29..32 }
+                                ^ Token { kind: RightParen, lexeme: ")", span: 32..33 }
+                                  ^^^^ Token { kind: Identifier, lexeme: "void", span: 34..38 }
+                                      ^ Token { kind: Semicolon, lexeme: ";", span: 38..39 }
+ extern C fn beginDrawing() void;
+ ^^^^^^ Token { kind: Keyword(Extern), lexeme: "extern", span: 41..47 }
+        ^ Token { kind: Identifier, lexeme: "C", span: 48..49 }
+          ^^ Token { kind: Keyword(Fn), lexeme: "fn", span: 50..52 }
+             ^^^^^^^^^^^^ Token { kind: Identifier, lexeme: "beginDrawing", span: 53..65 }
+                         ^ Token { kind: LeftParen, lexeme: "(", span: 65..66 }
+                          ^ Token { kind: RightParen, lexeme: ")", span: 66..67 }
+                            ^^^^ Token { kind: Identifier, lexeme: "void", span: 68..72 }
+                                ^ Token { kind: Semicolon, lexeme: ";", span: 72..73 }
+ extern C fn drawText(*u8, s32, s32, s32, u32) void;
+ ^^^^^^ Token { kind: Keyword(Extern), lexeme: "extern", span: 75..81 }
+        ^ Token { kind: Identifier, lexeme: "C", span: 82..83 }
+          ^^ Token { kind: Keyword(Fn), lexeme: "fn", span: 84..86 }
+             ^^^^^^^^ Token { kind: Identifier, lexeme: "drawText", span: 87..95 }
+                     ^ Token { kind: LeftParen, lexeme: "(", span: 95..96 }
+                      ^ Token { kind: Star, lexeme: "*", span: 96..97 }
+                       ^^ Token { kind: Identifier, lexeme: "u8", span: 97..99 }
+                         ^ Token { kind: Comma, lexeme: ",", span: 99..100 }
+                           ^^^ Token { kind: Identifier, lexeme: "s32", span: 101..104 }
+                              ^ Token { kind: Comma, lexeme: ",", span: 104..105 }
+                                ^^^ Token { kind: Identifier, lexeme: "s32", span: 106..109 }
+                                   ^ Token { kind: Comma, lexeme: ",", span: 109..110 }
+                                     ^^^ Token { kind: Identifier, lexeme: "s32", span: 111..114 }
+                                        ^ Token { kind: Comma, lexeme: ",", span: 114..115 }
+                                          ^^^ Token { kind: Identifier, lexeme: "u32", span: 116..119 }
+                                             ^ Token { kind: RightParen, lexeme: ")", span: 119..120 }
+                                               ^^^^ Token { kind: Identifier, lexeme: "void", span: 121..125 }
+                                                   ^ Token { kind: Semicolon, lexeme: ";", span: 125..126 }
+ extern C fn closeWindow() void;
+ ^^^^^^ Token { kind: Keyword(Extern), lexeme: "extern", span: 128..134 }
+        ^ Token { kind: Identifier, lexeme: "C", span: 135..136 }
+          ^^ Token { kind: Keyword(Fn), lexeme: "fn", span: 137..139 }
+             ^^^^^^^^^^^ Token { kind: Identifier, lexeme: "closeWindow", span: 140..151 }
+                        ^ Token { kind: LeftParen, lexeme: "(", span: 151..152 }
+                         ^ Token { kind: RightParen, lexeme: ")", span: 152..153 }
+                           ^^^^ Token { kind: Identifier, lexeme: "void", span: 154..158 }
+                               ^ Token { kind: Semicolon, lexeme: ";", span: 158..159 }
+
+ pub fn main() void {
+ ^^^ Token { kind: Keyword(Pub), lexeme: "pub", span: 162..165 }
+     ^^ Token { kind: Keyword(Fn), lexeme: "fn", span: 166..168 }
+        ^^^^ Token { kind: Identifier, lexeme: "main", span: 169..173 }
+            ^ Token { kind: LeftParen, lexeme: "(", span: 173..174 }
+             ^ Token { kind: RightParen, lexeme: ")", span: 174..175 }
+               ^^^^ Token { kind: Identifier, lexeme: "void", span: 176..180 }
+                    ^ Token { kind: LeftBrace, lexeme: "{", span: 181..182 }
+     initWindow(800, 600);
+     ^^^^^^^^^^ Token { kind: Identifier, lexeme: "initWindow", span: 188..198 }
+               ^ Token { kind: LeftParen, lexeme: "(", span: 198..199 }
+                ^^^ Token { kind: Number, lexeme: "800", span: 199..202 }
+                   ^ Token { kind: Comma, lexeme: ",", span: 202..203 }
+                     ^^^ Token { kind: Number, lexeme: "600", span: 204..207 }
+                        ^ Token { kind: RightParen, lexeme: ")", span: 207..208 }
+                         ^ Token { kind: Semicolon, lexeme: ";", span: 208..209 }
+     beginDrawing();
+     ^^^^^^^^^^^^ Token { kind: Identifier, lexeme: "beginDrawing", span: 215..227 }
+                 ^ Token { kind: LeftParen, lexeme: "(", span: 227..228 }
+                  ^ Token { kind: RightParen, lexeme: ")", span: 228..229 }
+                   ^ Token { kind: Semicolon, lexeme: ";", span: 229..230 }
+     closeWindow();
+     ^^^^^^^^^^^ Token { kind: Identifier, lexeme: "closeWindow", span: 236..247 }
+                ^ Token { kind: LeftParen, lexeme: "(", span: 247..248 }
+                 ^ Token { kind: RightParen, lexeme: ")", span: 248..249 }
+                  ^ Token { kind: Semicolon, lexeme: ";", span: 249..250 }
+ }
+ ^ Token { kind: RightBrace, lexeme: "}", span: 252..253 }

--- a/src/stage/lexer/tests.rs
+++ b/src/stage/lexer/tests.rs
@@ -43,3 +43,4 @@ macro_rules! snapshot {
 }
 
 snapshot!(hello_world, "../../../examples/hello_world.cb");
+snapshot!(extern_function, "../../../examples/extern.cb");

--- a/src/stage/lexer/token.rs
+++ b/src/stage/lexer/token.rs
@@ -58,9 +58,11 @@ pub enum TokenKind {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Keyword {
     And,
+    As,
     Const,
     Else,
     Enum,
+    Extern,
     False,
     Fn,
     For,
@@ -81,9 +83,11 @@ impl std::fmt::Display for Keyword {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::And => write!(f, "and"),
+            Self::As => write!(f, "as"),
             Self::Const => write!(f, "const"),
             Self::Else => write!(f, "else"),
             Self::Enum => write!(f, "enum"),
+            Self::Extern => write!(f, "extern"),
             Self::False => write!(f, "false"),
             Self::Fn => write!(f, "fn"),
             Self::For => write!(f, "for"),

--- a/src/stage/lexer/tokenizer.rs
+++ b/src/stage/lexer/tokenizer.rs
@@ -63,9 +63,11 @@ impl<'a> Tokenizer<'a> {
 
         let kind = match lexeme.as_str() {
             "and" => TokenKind::Keyword(Keyword::And),
+            "as" => TokenKind::Keyword(Keyword::As),
             "const" => TokenKind::Keyword(Keyword::Const),
             "else" => TokenKind::Keyword(Keyword::Else),
             "enum" => TokenKind::Keyword(Keyword::Enum),
+            "extern" => TokenKind::Keyword(Keyword::Extern),
             "false" => TokenKind::Keyword(Keyword::False),
             "fn" => TokenKind::Keyword(Keyword::Fn),
             "for" => TokenKind::Keyword(Keyword::For),

--- a/src/stage/parser/ast.rs
+++ b/src/stage/parser/ast.rs
@@ -131,6 +131,31 @@ pub enum Item {
     Function(Function),
     Type(TypeDef),
     Use(Use),
+    ExternFunction(ExternFunction),
+}
+
+#[derive(Debug)]
+pub struct ExternFunction {
+    pub visibility: Visibility,
+    pub extern_token: Token,
+    pub fn_token: Token,
+    pub calling_convention: Token,
+    pub binding_name: Token,
+    pub local_name: Option<Token>,
+    pub params: Vec<Type>,
+    pub return_type: Type,
+}
+
+impl ExternFunction {
+    pub fn span(&self) -> Span {
+        let start = self.extern_token.span.start;
+        let end = self
+            .local_name
+            .as_ref()
+            .map(|n| n.span.end)
+            .unwrap_or(self.binding_name.span.end);
+        start..end
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/stage/parser/syntax_analyzer.rs
+++ b/src/stage/parser/syntax_analyzer.rs
@@ -38,6 +38,10 @@ impl Parser {
             };
 
             match token.kind {
+                TokenKind::Keyword(Keyword::Extern) => {
+                    let extern_function = self.parse_extern_function(visibility)?;
+                    items.push(ast::Item::ExternFunction(extern_function));
+                }
                 TokenKind::Keyword(Keyword::Fn) => {
                     let function = self.parse_function(visibility)?;
                     items.push(ast::Item::Function(function));
@@ -103,6 +107,45 @@ impl Parser {
             Some(_) => Ok(ast::Visibility::Private),
             None => Err(Box::new(ErrorUnexpectedEndOfInput)),
         }
+    }
+
+    fn parse_extern_function(
+        &mut self,
+        visibility: ast::Visibility,
+    ) -> Result<ast::ExternFunction> {
+        let extern_token = self.consume(TokenKind::Keyword(Keyword::Extern))?;
+        let calling_convention = self.consume(TokenKind::Identifier)?;
+        let fn_token = self.consume(TokenKind::Keyword(Keyword::Fn))?;
+        let (binding_name, local_name) = self.consume(TokenKind::Identifier).and_then(|bn| {
+            if !self.peek(TokenKind::Keyword(Keyword::As)) {
+                return Ok((bn, None));
+            }
+            self.consume(TokenKind::Keyword(Keyword::As))?;
+            Ok((bn, self.consume(TokenKind::Identifier).ok()))
+        })?;
+        self.consume(TokenKind::LeftParen)?;
+        let mut params = Vec::new();
+        while !self.peek(TokenKind::RightParen) {
+            let ty = self.parse_type()?;
+            eprintln!("{:?}", ty);
+            params.push(ty);
+            if self.peek(TokenKind::Comma) {
+                self.consume(TokenKind::Comma)?;
+            }
+        }
+        self.consume(TokenKind::RightParen)?;
+        let return_type = self.parse_type()?;
+        self.consume(TokenKind::Semicolon)?;
+        Ok(ast::ExternFunction {
+            visibility,
+            extern_token,
+            fn_token,
+            calling_convention,
+            binding_name,
+            local_name,
+            params,
+            return_type,
+        })
     }
 
     fn parse_type_def(&mut self, visibility: ast::Visibility) -> Result<ast::TypeDef> {

--- a/src/stage/semantic_analyzer/symbol_table.rs
+++ b/src/stage/semantic_analyzer/symbol_table.rs
@@ -99,6 +99,7 @@ impl SymbolTableBuilder {
             ast::Item::Function(function) => self.walk_function(function),
             ast::Item::Type(type_def) => self.walk_type_def(type_def),
             ast::Item::Use(r#use) => self.walk_use(r#use),
+            ast::Item::ExternFunction(extern_function) => todo!(),
         }
     }
 

--- a/src/stage/semantic_analyzer/symbol_table.rs
+++ b/src/stage/semantic_analyzer/symbol_table.rs
@@ -99,7 +99,7 @@ impl SymbolTableBuilder {
             ast::Item::Function(function) => self.walk_function(function),
             ast::Item::Type(type_def) => self.walk_type_def(type_def),
             ast::Item::Use(r#use) => self.walk_use(r#use),
-            ast::Item::ExternFunction(extern_function) => todo!(),
+            ast::Item::ExternFunction(_) => todo!(),
         }
     }
 

--- a/src/stage/semantic_analyzer/type_check.rs
+++ b/src/stage/semantic_analyzer/type_check.rs
@@ -81,6 +81,7 @@ impl<'st> TypeChecker<'st> {
             ast::Item::Function(function) => self.walk_function(function),
             ast::Item::Type(type_def) => self.walk_type_def(type_def),
             ast::Item::Use(r#use) => self.walk_use(r#use),
+            ast::Item::ExternFunction(extern_function) => todo!(),
         }
     }
 

--- a/src/stage/semantic_analyzer/type_resolver.rs
+++ b/src/stage/semantic_analyzer/type_resolver.rs
@@ -50,6 +50,7 @@ impl<'st> TypeResolver<'st> {
             ast::Item::Function(function) => self.walk_function(function),
             ast::Item::Type(type_def) => self.walk_type_def(type_def),
             ast::Item::Use(r#use) => self.walk_use(r#use),
+            ast::Item::ExternFunction(extern_function) => todo!(),
         }
     }
 


### PR DESCRIPTION
Closes #8

This PR implements a parser method for `extern` function for the language.  Test for the scanner have been added with snapshot of the example file.   Parser test are not setup so we will implement that at a later date.
Also we added `extern` key word to the vim syntax file.