### PR TITLE
feat(x86_64): type casting linux

### DIFF
--- a/bitbox/src/backend/x86_64/linux/passes/emit/assembler/mod.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/assembler/mod.rs
@@ -261,6 +261,14 @@ pub enum Instruction {
     // Integer → float conversions
     Cvtsi2ss(Location, Location),
     Cvtsi2sd(Location, Location),
+    // Float → float conversions
+    Cvtss2sd(Location, Location),
+    Cvtsd2ss(Location, Location),
+    // Float → int conversions (truncating toward zero)
+    Cvttss2si(Location, Location),
+    Cvttsd2si(Location, Location),
+    // Sign-extending move
+    Movsx(Location, Location),
     // Integer division (rdx:rax implicit)
     Cqo,
     Idiv(Location),
@@ -317,6 +325,11 @@ impl std::fmt::Display for Instruction {
             Self::Ucomisd(dst, src) => write!(f, "  ucomisd {dst}, {src}"),
             Self::Cvtsi2ss(dst, src) => write!(f, "  cvtsi2ss {dst}, {src}"),
             Self::Cvtsi2sd(dst, src) => write!(f, "  cvtsi2sd {dst}, {src}"),
+            Self::Cvtss2sd(dst, src) => write!(f, "  cvtss2sd {dst}, {src}"),
+            Self::Cvtsd2ss(dst, src) => write!(f, "  cvtsd2ss {dst}, {src}"),
+            Self::Cvttss2si(dst, src) => write!(f, "  cvttss2si {dst}, {src}"),
+            Self::Cvttsd2si(dst, src) => write!(f, "  cvttsd2si {dst}, {src}"),
+            Self::Movsx(dst, src) => write!(f, "  movsx {dst}, {src}"),
             Self::Cqo => write!(f, "  cqo"),
             Self::Idiv(src) => write!(f, "  idiv {src}"),
         }
@@ -950,6 +963,46 @@ impl Assembler {
         self.push_to(
             self.current_section,
             Instruction::Cvtsi2sd(dst.into(), src.into()),
+        );
+        self
+    }
+
+    pub fn cvtss2sd(&mut self, dst: impl Into<Location>, src: impl Into<Location>) -> &mut Self {
+        self.push_to(
+            self.current_section,
+            Instruction::Cvtss2sd(dst.into(), src.into()),
+        );
+        self
+    }
+
+    pub fn cvtsd2ss(&mut self, dst: impl Into<Location>, src: impl Into<Location>) -> &mut Self {
+        self.push_to(
+            self.current_section,
+            Instruction::Cvtsd2ss(dst.into(), src.into()),
+        );
+        self
+    }
+
+    pub fn cvttss2si(&mut self, dst: impl Into<Location>, src: impl Into<Location>) -> &mut Self {
+        self.push_to(
+            self.current_section,
+            Instruction::Cvttss2si(dst.into(), src.into()),
+        );
+        self
+    }
+
+    pub fn cvttsd2si(&mut self, dst: impl Into<Location>, src: impl Into<Location>) -> &mut Self {
+        self.push_to(
+            self.current_section,
+            Instruction::Cvttsd2si(dst.into(), src.into()),
+        );
+        self
+    }
+
+    pub fn movsx(&mut self, dst: impl Into<Location>, src: impl Into<Location>) -> &mut Self {
+        self.push_to(
+            self.current_section,
+            Instruction::Movsx(dst.into(), src.into()),
         );
         self
     }

--- a/bitbox/src/backend/x86_64/linux/passes/emit/instruction.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/instruction.rs
@@ -6,8 +6,8 @@ use crate::backend::x86_64::linux::passes::emit::assembler::{
 };
 use crate::backend::x86_64::linux::passes::emit::error::Error;
 use crate::ir::instruction::{
-    IAdd, IAlloc, IAnd, IAssign, ICall, ICmp, IDiv, IElemGet, IElemSet, IGt, IGte, IJump, IJumpIf,
-    ILt, IMul, INot, IRef, IRem, IReturn, ISub,
+    CastKind, IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, IDiv, IElemGet, IElemSet, IGt, IGte,
+    IJump, IJumpIf, ILt, IMul, INot, IRef, IRem, IReturn, ISub,
 };
 use crate::ir::{AbiChunk, Operand, Type};
 
@@ -1399,6 +1399,155 @@ impl Lower<X86_64LinuxLowerContext<'_>> for INot {
         let out = target.assembler.alloc.vreg::<Reg64>();
         target.assembler.movezx(out, flag_reg);
         target.assembler.alloc.store_variable(&self.des, out);
+        Ok(())
+    }
+}
+
+impl Lower<X86_64LinuxLowerContext<'_>> for ICast {
+    type Output = ();
+    fn lower(
+        &self,
+        _ctx: &mut crate::backend::Context,
+        target: &mut X86_64LinuxLowerContext<'_>,
+    ) -> Result<Self::Output, crate::error::Error> {
+        target.assembler.comment("lowering cast");
+        let src = Operand::Variable(self.src.clone()).lower(_ctx, target)?;
+        let src_val = target.assembler.materialize_value(&src);
+        let src_ty = self.src.ty.clone();
+        let dst_ty = self.des.ty.clone();
+
+        match self.kind {
+            // ── Sign-extend: smaller signed → larger signed ─────────────────
+            CastKind::SignExtend => {
+                let dst_reg = target.assembler.alloc.vreg::<Reg64>();
+                let sized_src = match src_ty.size() {
+                    1 => src_val.cast_to::<Reg8>(),
+                    2 => src_val.cast_to::<Reg16>(),
+                    4 => src_val.cast_to::<Reg32>(),
+                    _ => src_val,
+                };
+                target.assembler.movsx(dst_reg, sized_src);
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(dst_reg));
+            }
+
+            // ── Zero-extend: smaller unsigned/bool → larger type ─────────────
+            CastKind::ZeroExtend => {
+                let dst_reg = target.assembler.alloc.vreg::<Reg64>();
+                let sized_src = match src_ty.size() {
+                    1 => src_val.cast_to::<Reg8>(),
+                    2 => src_val.cast_to::<Reg16>(),
+                    4 => src_val.cast_to::<Reg32>(),
+                    _ => src_val,
+                };
+                target.assembler.movezx(dst_reg, sized_src);
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(dst_reg));
+            }
+
+            // ── Truncate: larger int → smaller int ───────────────────────────
+            CastKind::Truncate => {
+                let dst_reg = target.assembler.alloc.vreg::<Reg64>();
+                // mov the full value, then narrow the register reference for the output.
+                target.assembler.mov(dst_reg, src_val);
+                let narrowed = match dst_ty.size() {
+                    1 => dst_reg.cast_to::<Reg8>(),
+                    2 => dst_reg.cast_to::<Reg16>(),
+                    4 => dst_reg.cast_to::<Reg32>(),
+                    _ => dst_reg,
+                };
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(narrowed));
+            }
+
+            // ── Int → Float ──────────────────────────────────────────────────
+            CastKind::IntToFloat => {
+                let xmm = target.assembler.alloc.vreg::<XmmReg>();
+                // cvtsi2ss/cvtsi2sd expect a 32- or 64-bit GP register source.
+                let gp_src = match src_ty.size() {
+                    8 => src_val,
+                    _ => src_val.cast_to::<Reg32>(),
+                };
+                match &dst_ty {
+                    Type::Float(32) => target.assembler.cvtsi2ss(Location::Reg(xmm), gp_src),
+                    Type::Float(64) => target.assembler.cvtsi2sd(Location::Reg(xmm), gp_src),
+                    _ => panic!(
+                        "ICast IntToFloat: destination must be Float, got {:?}",
+                        dst_ty
+                    ),
+                };
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(xmm));
+            }
+
+            // ── Float → Int (truncating toward zero) ─────────────────────────
+            CastKind::FloatToInt => {
+                let dst_reg = target.assembler.alloc.vreg::<Reg64>();
+                let gp_dst = match dst_ty.size() {
+                    8 => dst_reg,
+                    _ => dst_reg.cast_to::<Reg32>(),
+                };
+                match &src_ty {
+                    Type::Float(32) => target.assembler.cvttss2si(gp_dst, src_val),
+                    Type::Float(64) => target.assembler.cvttsd2si(gp_dst, src_val),
+                    _ => panic!("ICast FloatToInt: source must be Float, got {:?}", src_ty),
+                };
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(dst_reg));
+            }
+
+            // ── Float width conversion ────────────────────────────────────────
+            CastKind::BitCast
+                if matches!((&src_ty, &dst_ty), (Type::Float(32), Type::Float(64))) =>
+            {
+                let xmm = target.assembler.alloc.vreg::<XmmReg>();
+                target.assembler.cvtss2sd(Location::Reg(xmm), src_val);
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(xmm));
+            }
+            CastKind::BitCast
+                if matches!((&src_ty, &dst_ty), (Type::Float(64), Type::Float(32))) =>
+            {
+                let xmm = target.assembler.alloc.vreg::<XmmReg>();
+                target.assembler.cvtsd2ss(Location::Reg(xmm), src_val);
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(xmm));
+            }
+
+            // ── Signed ↔ Unsigned reinterpret (same bit width, no-op) ────────
+            CastKind::UnsignedToSigned
+            | CastKind::SignedToUnsigned
+            | CastKind::BitCast
+            | CastKind::NoOp => {
+                let dst_reg = target.assembler.alloc.vreg::<Reg64>();
+                target.assembler.mov(dst_reg, src_val);
+                let narrowed = match dst_ty.size() {
+                    1 => dst_reg.cast_to::<Reg8>(),
+                    2 => dst_reg.cast_to::<Reg16>(),
+                    4 => dst_reg.cast_to::<Reg32>(),
+                    _ => dst_reg,
+                };
+                target
+                    .assembler
+                    .alloc
+                    .store_variable(&self.des, Location::Reg(narrowed));
+            }
+        }
+
         Ok(())
     }
 }

--- a/bitbox/src/backend/x86_64/linux/passes/emit/mod.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/mod.rs
@@ -334,6 +334,7 @@ impl Lower<X86_64LinuxLowerContext<'_>> for ir::Instruction {
             ir::Instruction::XOr(..) => todo!("xor"),
             ir::Instruction::Ref(iref) => iref.lower(ctx, target)?,
             ir::Instruction::Not(inot) => inot.lower(ctx, target)?,
+            ir::Instruction::Cast(icast) => icast.lower(ctx, target)?,
         }
         Ok(())
     }

--- a/bitbox/src/backend/x86_64/linux/passes/virt_reg_rewrite.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/virt_reg_rewrite.rs
@@ -159,6 +159,11 @@ fn map_locations(
         Instruction::Ucomisd(a, b) => Instruction::Ucomisd(rw(a), rw(b)),
         Instruction::Cvtsi2ss(a, b) => Instruction::Cvtsi2ss(rw(a), rw(b)),
         Instruction::Cvtsi2sd(a, b) => Instruction::Cvtsi2sd(rw(a), rw(b)),
+        Instruction::Cvtss2sd(a, b) => Instruction::Cvtss2sd(rw(a), rw(b)),
+        Instruction::Cvtsd2ss(a, b) => Instruction::Cvtsd2ss(rw(a), rw(b)),
+        Instruction::Cvttss2si(a, b) => Instruction::Cvttss2si(rw(a), rw(b)),
+        Instruction::Cvttsd2si(a, b) => Instruction::Cvttsd2si(rw(a), rw(b)),
+        Instruction::Movsx(a, b) => Instruction::Movsx(rw(a), rw(b)),
         Instruction::Idiv(a) => Instruction::Idiv(rw(a)),
         other => other,
     }

--- a/bitbox/src/ir/builder.rs
+++ b/bitbox/src/ir/builder.rs
@@ -2,9 +2,9 @@ use crate::ir::{
     BasicBlock, BlockId, Constant, ExternDecl, Function, Import, Instruction, Module, Operand,
     Type, Variable, Visibility,
     instruction::{
-        IAdd, IAlloc, IAnd, IAssign, ICall, ICmp, IDiv, IElemGet, IElemSet, IGt, IGte, IIfElse,
-        IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef, IRem, IReturn, ISub,
-        IXOr, Label,
+        CastKind, IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, IDiv, IElemGet, IElemSet, IGt,
+        IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef, IRem,
+        IReturn, ISub, IXOr, Label,
     },
 };
 
@@ -219,8 +219,15 @@ impl<'a> AssemblerBuilder<'a> {
         self
     }
 
+    /// `@not <type> : <des>, <src>`
     pub fn not(&mut self, des: Variable, src: Variable) -> &mut Self {
         self.push_instruction(INot::new(des, src));
+        self
+    }
+
+    /// @cast <type> : <des>, <src>, <dest_ty>
+    pub fn cast(&mut self, des: Variable, src: Variable, cast_kind: CastKind) -> &mut Self {
+        self.push_instruction(ICast::new(des, src, cast_kind));
         self
     }
 

--- a/bitbox/src/ir/instruction.rs
+++ b/bitbox/src/ir/instruction.rs
@@ -78,6 +78,8 @@ pub enum Instruction {
     /// `@not bool : <des>, <src>`
     /// Logical NOT: des = !src
     Not(INot),
+    /// `@cast <kind> <type> : <des>, <src>`
+    Cast(ICast),
 }
 
 impl fmt::Display for Instruction {
@@ -111,6 +113,7 @@ impl fmt::Display for Instruction {
             Self::Loop(iloop) => write!(f, "{iloop}"),
             Self::Ref(iref) => write!(f, "{iref}"),
             Self::Not(inot) => write!(f, "{inot}"),
+            Self::Cast(icast) => write!(f, "{icast}"),
         }
     }
 }
@@ -823,5 +826,85 @@ impl fmt::Display for INot {
 impl From<INot> for Instruction {
     fn from(i: INot) -> Self {
         Instruction::Not(i)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CastKind {
+    Truncate,
+    ZeroExtend,
+    SignExtend,
+    UnsignedToSigned,
+    SignedToUnsigned,
+    FloatToInt,
+    IntToFloat,
+    BitCast,
+    NoOp,
+}
+
+impl fmt::Display for CastKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::Truncate => "truncate",
+            Self::ZeroExtend => "zero-extend",
+            Self::SignExtend => "sign-extend",
+            Self::UnsignedToSigned => "unsigned-to-signed",
+            Self::SignedToUnsigned => "signed-to-unsigned",
+            Self::FloatToInt => "float-to-int",
+            Self::IntToFloat => "int-to-float",
+            Self::BitCast => "bitcast",
+            Self::NoOp => "noop",
+        };
+        write!(f, "{}", kind)
+    }
+}
+
+/// `@cast <type> : <des>, <src>, <kind>`
+/// Casts `src` to `type` using the specified `kind` of cast, and stores the result in `des`.
+/// `kind` can be one of:
+/// - `truncate`: to a smaller type (e.g. s32 to s8)
+/// - `zero-extend `: to a larger type (e.g. s32 to s64)
+/// - `sign-extend`: to a larger type (e.g. s32 to s64)
+/// - `unsigned-to-signed`: from an unsigned type to a signed type of the same size (e.g. u32 to s32)
+/// - `signed-to-unsigned`: from a signed type to an unsigned type of the same
+/// - `float-to-int`: from a floating point type to an integer type (e.g. f32 to s32)
+/// - `int-to-float`: from an integer type to a floating point type (e.g. s32 to f32)
+/// - `bitcast`: reinterpret the bits as another type (e.g. s32 to f32)
+/// Example:
+/// `@cast u8 : small, large, truncate `
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ICast {
+    pub kind: CastKind,
+    pub des: Variable,
+    pub src: Variable,
+}
+
+impl ICast {
+    pub fn new(des: impl Into<Variable>, src: impl Into<Variable>, kind: CastKind) -> Self {
+        Self {
+            kind,
+            des: des.into(),
+            src: src.into(),
+        }
+    }
+}
+
+impl fmt::Display for ICast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} {:<5} : {}, {}, {}",
+            Paint::blue("@cast"),
+            Paint::yellow(&self.des.ty),
+            color_var(&self.des),
+            color_var(&self.src),
+            Paint::yellow(&self.kind),
+        )
+    }
+}
+
+impl From<ICast> for Instruction {
+    fn from(i: ICast) -> Self {
+        Instruction::Cast(i)
     }
 }

--- a/bitbox/src/passes/liveness.rs
+++ b/bitbox/src/passes/liveness.rs
@@ -2,9 +2,9 @@ use crate::{
     ir::{
         BasicBlock, BlockId, Instruction, Variable,
         instruction::{
-            IAdd, IAlloc, IAnd, IAssign, ICall, ICmp, ICopy, IDiv, IElemGet, IElemSet, IGt, IGte,
-            IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef, IRem,
-            IReturn, ISub, IXOr,
+            IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, ICopy, IDiv, IElemGet, IElemSet, IGt,
+            IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef,
+            IRem, IReturn, ISub, IXOr,
         },
     },
     passes::{DebugPass, PassOutput},
@@ -307,6 +307,15 @@ impl LivenessAnalysis for INot {
     }
 }
 
+impl LivenessAnalysis for ICast {
+    fn uses(&self) -> Vec<Variable> {
+        vec![self.src.clone()]
+    }
+    fn defines(&self) -> Vec<Variable> {
+        vec![self.des.clone()]
+    }
+}
+
 impl crate::ir::Instruction {
     pub fn uses(&self) -> Vec<Variable> {
         match self {
@@ -338,6 +347,7 @@ impl crate::ir::Instruction {
             Self::Loop(i) => i.uses(),
             Self::Ref(i) => i.uses(),
             Self::Not(i) => i.uses(),
+            Self::Cast(i) => i.uses(),
         }
     }
 
@@ -371,6 +381,7 @@ impl crate::ir::Instruction {
             Self::Loop(i) => i.defines(),
             Self::Ref(i) => i.defines(),
             Self::Not(i) => i.defines(),
+            Self::Cast(i) => i.defines(),
         }
     }
 }

--- a/bitbox/src/passes/local_function_variables.rs
+++ b/bitbox/src/passes/local_function_variables.rs
@@ -222,6 +222,12 @@ fn block_pass(
                 ctx.local_function_variables
                     .add(function_name, inot.src.clone());
             }
+            crate::ir::Instruction::Cast(icast) => {
+                ctx.local_function_variables
+                    .add(function_name, icast.des.clone());
+                ctx.local_function_variables
+                    .add(function_name, icast.src.clone());
+            }
         }
     }
 }

--- a/examples/casting.cb
+++ b/examples/casting.cb
@@ -1,0 +1,8 @@
+extern C fn write_int(s32) void;
+extern C fn write_char(u8) void;
+
+pub fn main() void {
+    let n: s32 = 97;
+    write_int(n);
+    write_char(n as u8);
+}

--- a/src/stage/ir_builder/mod.rs
+++ b/src/stage/ir_builder/mod.rs
@@ -12,7 +12,7 @@ use bitbox::ir::{
 use crate::stage::parser::ast::{
     Expr, ExprAddressOf, ExprArray, ExprArrayIndex, ExprArrayRepeat, ExprAssignment, ExprBinary,
     ExprBlock, ExprCall, ExprDecl, ExprGrouping, ExprIfElse, ExprMemberAccess, ExprNot, ExprReturn,
-    ExprStruct, ExprWhile, Litral, Struct,
+    ExprStruct, ExprTypeCast, ExprWhile, Litral, Struct,
 };
 
 #[derive(Debug, Default)]
@@ -199,6 +199,7 @@ impl Lowerable for Expr {
             Expr::AddressOf(expr) => expr.lower(assembler, ctx),
             Expr::Not(expr) => expr.lower(assembler, ctx),
             Expr::Grouping(expr) => expr.lower(assembler, ctx),
+            Expr::TypeCast(expr) => expr.lower(assembler, ctx),
         }
     }
 }
@@ -838,6 +839,35 @@ impl Lowerable for ExprGrouping {
         ctx: &mut LoweringContext,
     ) -> Option<Variable> {
         let des = self.expr.lower(assembler, ctx)?;
+        Some(des)
+    }
+}
+
+impl Lowerable for ExprTypeCast {
+    fn lower(
+        &self,
+        assembler: &mut AssemblerBuilder,
+        ctx: &mut LoweringContext,
+    ) -> Option<Variable> {
+        let src_var = self.expr.lower(assembler, ctx)?;
+        let des_ty = self.target_type.as_bitbox_type();
+        let src_ty = src_var.ty.clone();
+        let des = assembler.var(des_ty.clone());
+        let cast_kind = match (des_ty, src_ty) {
+            (Type::Signed(_), Type::Unsigned(_)) => ir::CastKind::UnsignedToSigned,
+            (Type::Unsigned(_), Type::Signed(_)) => ir::CastKind::SignedToUnsigned,
+            (Type::Float(_), Type::Signed(_)) => ir::CastKind::IntToFloat,
+            (Type::Float(_), Type::Unsigned(_)) => ir::CastKind::IntToFloat,
+            (Type::Signed(_), Type::Float(_)) => ir::CastKind::FloatToInt,
+            (Type::Unsigned(_), Type::Float(_)) => ir::CastKind::FloatToInt,
+            (dst, src) if dst == src => ir::CastKind::NoOp,
+            _ => unimplemented!(
+                "Unsupported cast from {:?} to {:?}",
+                src_var.ty,
+                self.target_type
+            ),
+        };
+        assembler.cast(des.clone(), src_var, cast_kind);
         Some(des)
     }
 }

--- a/src/stage/parser/ast.rs
+++ b/src/stage/parser/ast.rs
@@ -311,34 +311,51 @@ pub enum Expr {
     AddressOf(ExprAddressOf),
     Not(ExprNot),
     Grouping(ExprGrouping),
+    TypeCast(ExprTypeCast),
 }
 
 impl Expr {
     pub fn span(&self) -> Span {
         match self {
-            Self::Return(expr_return) => expr_return.span(),
-            Self::Struct(expr_struct) => expr_struct.span(),
-            Self::Declare(expr_decl) => expr_decl.span(),
-            Self::Assignment(expr_assignment) => expr_assignment.span(),
+            Self::Return(expr) => expr.span(),
+            Self::Struct(expr) => expr.span(),
+            Self::Declare(expr) => expr.span(),
+            Self::Assignment(expr) => expr.span(),
             Self::Litral(litral) => litral.span(),
-            Self::Call(expr_call) => expr_call.span(),
-            Self::Binary(expr_binary) => expr_binary.span(),
-            Self::While(expr_while) => expr_while.span(),
+            Self::Call(expr) => expr.span(),
+            Self::Binary(expr) => expr.span(),
+            Self::While(expr) => expr.span(),
             Self::Identifier(token) => token.span.clone(),
-            Self::IfElse(expr_if_else) => expr_if_else.span(),
+            Self::IfElse(expr) => expr.span(),
             Self::MemberAccess(expr) => expr.span(),
             Self::Array(expr) => expr.span(),
             Self::ArrayIndex(expr) => expr.span(),
             Self::ArrayRepeat(expr) => expr.span(),
-            Self::Block(block) => block.span(),
+            Self::Block(expr) => expr.span(),
             Self::AddressOf(expr) => expr.span(),
             Self::Not(expr) => expr.span(),
-            Self::Grouping(grouping) => grouping.span(),
+            Self::Grouping(expr) => expr.span(),
+            Self::TypeCast(expr) => expr.span(),
         }
     }
 
     pub fn is_addressable(&self) -> bool {
         matches!(self, Expr::Identifier(..) | Expr::ArrayIndex(..))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExprTypeCast {
+    pub as_token: Token,
+    pub expr: Box<Expr>,
+    pub target_type: Type,
+}
+
+impl ExprTypeCast {
+    pub fn span(&self) -> Span {
+        let start = self.as_token.span.start;
+        let end = self.expr.span().end;
+        start..end
     }
 }
 

--- a/src/stage/parser/syntax_analyzer.rs
+++ b/src/stage/parser/syntax_analyzer.rs
@@ -440,7 +440,7 @@ impl Parser {
 
     fn parse_comparison(&mut self) -> Result<ast::Expr> {
         use TokenKind::*;
-        let mut left = self.parse_term()?;
+        let mut left = self.parse_type_casting()?;
         while let Some(op) = self.lexer.next_if(one_of(&[
             Greater,
             Less,
@@ -449,13 +449,30 @@ impl Parser {
             EqualEqual,
             BangEqual,
         ])) {
-            let right = self.parse_term()?;
+            let right = self.parse_type_casting()?;
             let binary_expr = ast::ExprBinary {
                 left: Box::new(left),
                 op,
                 right: Box::new(right),
             };
             left = ast::Expr::Binary(binary_expr);
+        }
+        Ok(left)
+    }
+
+    fn parse_type_casting(&mut self) -> Result<ast::Expr> {
+        let mut left = self.parse_term()?;
+        while let Some(op) = self
+            .lexer
+            .next_if(one_of(&[TokenKind::Keyword(Keyword::As)]))
+        {
+            let target_type = self.parse_type()?;
+            let binary_expr = ast::ExprTypeCast {
+                expr: Box::new(left),
+                target_type,
+                as_token: op,
+            };
+            left = ast::Expr::TypeCast(binary_expr)
         }
         Ok(left)
     }

--- a/src/stage/semantic_analyzer/symbol_table.rs
+++ b/src/stage/semantic_analyzer/symbol_table.rs
@@ -158,7 +158,11 @@ impl SymbolTableBuilder {
             Expr::MemberAccess(expr) => self.walk_expr_member_access(expr),
             Expr::Return(..) => todo!(),
             Expr::Litral(..) => {}
-            Expr::Array(..) => todo!(),
+            Expr::Array(expr_array) => {
+                for expr in expr_array.elements.iter() {
+                    self.walk_expr(expr);
+                }
+            }
             Expr::ArrayIndex(expr) => {
                 self.walk_expr(&expr.expr);
                 self.walk_expr(&expr.index);
@@ -171,6 +175,7 @@ impl SymbolTableBuilder {
             Expr::AddressOf(expr) => self.walk_expr(&expr.expr),
             Expr::Not(expr) => self.walk_expr(&expr.expr),
             Expr::Grouping(expr_grouping) => self.walk_expr(&expr_grouping.expr),
+            Expr::TypeCast(cast) => self.walk_expr(&cast.expr),
         }
     }
 

--- a/src/stage/semantic_analyzer/type_check.rs
+++ b/src/stage/semantic_analyzer/type_check.rs
@@ -205,6 +205,7 @@ impl<'st> TypeChecker<'st> {
             ast::Expr::Struct(expr) => self.walk_expr_struct(expr),
             ast::Expr::While(expr) => self.walk_expr_while(expr),
             ast::Expr::Grouping(expr_grouping) => self.walk_expr(&mut expr_grouping.expr),
+            ast::Expr::TypeCast(expr_cast) => expr_cast.target_type.clone(),
         }
     }
 
@@ -284,14 +285,19 @@ impl<'st> TypeChecker<'st> {
         }
     }
 
-    fn walk_expr_call(&mut self, expr: &ast::ExprCall) -> ast::Type {
+    fn walk_expr_call(&mut self, expr: &mut ast::ExprCall) -> ast::Type {
         let ast::Expr::Identifier(ident) = &expr.caller.as_ref() else {
             panic!("Caller must be an identifier");
         };
 
-        let Some(symbol) = self.symbol_table.get(ident.lexeme.as_str()) else {
+        let Some(symbol) = self.symbol_table.get(ident.lexeme.as_str()).cloned() else {
             unreachable!("If seeing this then. Welp I guess I was wrong.");
         };
+
+        for arg in expr.args.iter_mut() {
+            self.walk_expr(arg);
+        }
+
         symbol.ty.clone()
     }
 

--- a/src/stage/semantic_analyzer/type_resolver.rs
+++ b/src/stage/semantic_analyzer/type_resolver.rs
@@ -112,6 +112,7 @@ impl<'st> TypeResolver<'st> {
             Expr::AddressOf(expr_address_of) => self.walk_expr(&mut expr_address_of.expr),
             Expr::Not(expr_not) => self.walk_expr(&mut expr_not.expr),
             Expr::Grouping(expr_grouping) => self.walk_expr(&mut expr_grouping.expr),
+            Expr::TypeCast(expr_cast) => self.walk_expr(&mut expr_cast.expr),
         }
     }
 


### PR DESCRIPTION
#18 
This PR only handles casting for x86 64 linux backend.  We will handle the wasm backend in a different PR. Also it is worth noting that this PR does not handle the Text form of the @cast instruction parsing.