### PR TITLE
feat(parser): generics in function signatures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -123,9 +123,7 @@ impl Report for ErrorExpectedType {
                 self.found.lexeme
             ))
             .with_lines_above(3)
-            .with_note(
-                "types must be defined as `u8`, `s8`, `u16`, `s16`, `u32`, `s32`, `f32`, `*`",
-            )
+            .with_note("types must be defined as `u8`, `s8`, `u16`, `s16`, `u32`, `s32`, `f32`")
             .build()
     }
 }
@@ -189,14 +187,23 @@ impl Report for Errors {
 }
 
 #[derive(Debug)]
-pub struct ErrorUndefinedSymbol {
-    pub found: Token,
+pub enum ErrorUndefinedSymbol {
+    Token(Token),
+    Type(Type),
 }
 
 impl Report for ErrorUndefinedSymbol {
     fn report(&self, filename: &str, src: &str) -> String {
-        ReportBuilder::new(filename, src, &self.found.span)
-            .with_message(format!("undefined symbol `{}`", &self.found.lexeme))
+        let span = match self {
+            ErrorUndefinedSymbol::Token(token) => &token.span,
+            ErrorUndefinedSymbol::Type(ty) => &ty.span,
+        };
+        let name = match self {
+            ErrorUndefinedSymbol::Token(token) => &token.lexeme,
+            ErrorUndefinedSymbol::Type(ty) => &ty.to_string(),
+        };
+        ReportBuilder::new(filename, src, &span)
+            .with_message(format!("undefined symbol `{}`", name))
             .build()
     }
 }

--- a/src/stage/ir_builder/mod.rs
+++ b/src/stage/ir_builder/mod.rs
@@ -621,6 +621,7 @@ impl Lowerable for ExprDecl {
                 .unwrap_or(&ast::Type {
                     kind: ast::TypeKind::default(),
                     span: expr.span(),
+                    ..Default::default()
                 })
                 .kind
                 .as_bitbox_type()

--- a/src/stage/parser/ast.rs
+++ b/src/stage/parser/ast.rs
@@ -1,10 +1,12 @@
 #![allow(unused)]
 use bitbox::text::semantic_analyzer::Symbol;
+use std::fmt::Write;
 
 use crate::stage::lexer::token::{Span, Token};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Type {
+    pub mut_token: Option<Token>,
     pub kind: TypeKind,
     pub span: Span,
 }
@@ -12,6 +14,7 @@ pub struct Type {
 impl Default for Type {
     fn default() -> Self {
         Self {
+            mut_token: None,
             kind: TypeKind::default(),
             span: 0..1,
         }
@@ -20,7 +23,8 @@ impl Default for Type {
 
 impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.kind)
+        let mutable = if self.mut_token.is_some() { "mut " } else { "" };
+        write!(f, "{mutable}{}", self.kind)
     }
 }
 
@@ -31,7 +35,8 @@ pub enum TypeKind {
     Enum(String),
     Float(u8),
     Name(String),
-    Pointer(Box<Type>),
+    NameWithParams(Token, TypeParams),
+    Ref(Box<Type>),
     SignedNumber(u8),
     Struct(StructType),
     UnsignedNumber(u8),
@@ -48,8 +53,18 @@ impl TypeKind {
             Self::Bool => bitbox::ir::Type::Unsigned(32),
             Self::Enum(name) => todo!("{name}"),
             Self::Float(bytes) => bitbox::ir::Type::Float(*bytes),
-            Self::Name(_) => unreachable!("Bro you screwed up"),
-            Self::Pointer(inner) => {
+            Self::Name(name) => {
+                unreachable!(
+                    "Type::Name({name}).as_bitbox_type() should be handled in type_resolver"
+                )
+            }
+            Self::NameWithParams(name, params) => {
+                unreachable!(
+                    "Type::Name({}, {params}).as_bitbox_type() should be handled in type_resolver",
+                    name.lexeme
+                )
+            }
+            Self::Ref(inner) => {
                 bitbox::ir::Type::Pointer(Box::new(inner.kind.clone().as_bitbox_type()))
             }
             Self::SignedNumber(bytes) => bitbox::ir::Type::Signed(*bytes),
@@ -72,8 +87,16 @@ impl TypeKind {
             Self::Array(count, ty) => count * ty.kind.size(),
             Self::Bool => 1,
             Self::Enum(_) => todo!("Size of enum"),
-            Self::Name(..) => unreachable!("Bro you screwed up"),
-            Self::Pointer(_) => 64,
+            Self::Name(name) => {
+                unreachable!("Type::Name({name}).size() should be handled in type_resolver")
+            }
+            Self::NameWithParams(name, params) => {
+                unreachable!(
+                    "Type::Name({}, {params}).size() should be handled in type_resolver",
+                    name.lexeme
+                )
+            }
+            Self::Ref(_) => 64,
             Self::Struct(struct_type) => {
                 let mut size = 0;
                 for (_, ty) in &struct_type.fields {
@@ -97,7 +120,8 @@ impl std::fmt::Display for TypeKind {
             Self::Float(n) => write!(f, "f{}", n),
             Self::Enum(name) => write!(f, "{}", name),
             Self::Name(name) => write!(f, "{}", name),
-            Self::Pointer(ty) => write!(f, "*{}", ty),
+            Self::NameWithParams(name, params) => write!(f, "{}({params})", name.lexeme),
+            Self::Ref(ty) => write!(f, "ref {ty}"),
             Self::SignedNumber(n) => write!(f, "s{}", n),
             Self::Struct(symbol) => write!(f, "{}", symbol.name),
             Self::UnsignedNumber(n) => write!(f, "u{}", n),
@@ -106,6 +130,25 @@ impl std::fmt::Display for TypeKind {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeParams {
+    pub params: Vec<Type>,
+}
+
+impl std::fmt::Display for TypeParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut string = String::new();
+        for (idx, param) in self.params.iter().enumerate() {
+            if idx == self.params.len().saturating_sub(1) {
+                write!(&mut string, "{}", param);
+                continue;
+            }
+            write!(&mut string, "{}, ", param);
+        }
+
+        write!(f, "{string}")
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructType {
     pub name: String,

--- a/src/stage/parser/syntax_analyzer.rs
+++ b/src/stage/parser/syntax_analyzer.rs
@@ -5,7 +5,7 @@ use crate::error::{
     ErrorUnexpectedEndOfInput, ErrorUnexpectedTopLevelItem, Result,
 };
 use crate::stage::lexer::token::{Keyword, Token, TokenKind};
-use crate::stage::parser::ast::{self, ExprMemberAccess};
+use crate::stage::parser::ast::{self, ExprMemberAccess, TypeParams};
 
 pub struct Parser {
     lexer: std::iter::Peekable<std::vec::IntoIter<Token>>,
@@ -241,20 +241,35 @@ impl Parser {
     }
 
     fn parse_type(&mut self) -> Result<ast::Type> {
-        // let ref_keyword = self.consume(TokenKind::Keyword(Keyword::Ref)).ok();
-        // let mut_keyword = self.consume(TokenKind::Keyword(Keyword::Mut)).ok();
-
+        let mut_token = self.consume_if_eq(TokenKind::Keyword(Keyword::Mut));
         let Some(tok) = self.lexer.next() else {
             return Err(Box::new(ErrorUnexpectedEndOfInput));
         };
 
         match tok.kind {
-            TokenKind::Identifier => token_as_type(&tok),
-            TokenKind::Star => {
+            TokenKind::Identifier if self.peek(TokenKind::LeftParen) => {
+                self.consume(TokenKind::LeftParen)?;
+                let mut params = Vec::new();
+                while !self.peek(TokenKind::RightParen) {
+                    let ty = self.parse_type()?;
+                    params.push(ty);
+                    self.consume_if_eq(TokenKind::Comma);
+                }
+                let right_param = self.consume(TokenKind::RightParen)?;
+                let span = mut_token.as_ref().unwrap_or(&tok).span.start..right_param.span.end;
+                Ok(ast::Type {
+                    mut_token,
+                    kind: ast::TypeKind::NameWithParams(tok, TypeParams { params }),
+                    span,
+                })
+            }
+            TokenKind::Identifier => token_as_type(mut_token, &tok),
+            TokenKind::Keyword(Keyword::Ref) => {
                 let ty = self.parse_type()?;
                 let span = tok.span.start..ty.span.end;
                 Ok(ast::Type {
-                    kind: ast::TypeKind::Pointer(Box::new(ty)),
+                    mut_token,
+                    kind: ast::TypeKind::Ref(Box::new(ty)),
                     span,
                 })
             }
@@ -265,6 +280,7 @@ impl Parser {
                 let closing_bracket = self.consume(TokenKind::RightBracket)?;
                 let span = tok.span.start..closing_bracket.span.end;
                 Ok(ast::Type {
+                    mut_token,
                     kind: ast::TypeKind::Array(count.lexeme.parse().unwrap(), Box::new(ty)),
                     span,
                 })
@@ -398,7 +414,7 @@ impl Parser {
             else_branch,
             ty: ast::Type {
                 kind: ast::TypeKind::Void,
-                span: 0..1,
+                ..Default::default()
             },
         };
         Ok(ast::Expr::IfElse(if_else_expr))
@@ -540,7 +556,7 @@ impl Parser {
                     close_bracket: right_bracket,
                     ty: ast::Type {
                         kind: ast::TypeKind::Void,
-                        span: 0..1,
+                        ..Default::default()
                     },
                 };
                 expr = ast::Expr::ArrayIndex(array_index);
@@ -688,7 +704,7 @@ impl Parser {
                 close_bracket,
                 ty: ast::Type {
                     kind: ast::TypeKind::Void,
-                    span: 0..1,
+                    ..Default::default()
                 },
             }));
         }
@@ -708,7 +724,7 @@ impl Parser {
                 close_bracket,
                 ty: ast::Type {
                     kind: ast::TypeKind::Void,
-                    span: 0..1,
+                    ..Default::default()
                 },
             }));
         }
@@ -735,7 +751,7 @@ impl Parser {
             // We will sent when we type check.
             ty: ast::Type {
                 kind: ast::TypeKind::Void,
-                span: 0..1,
+                ..Default::default()
             },
             close_bracket,
         }))
@@ -746,7 +762,7 @@ fn one_of(tokens: &[TokenKind]) -> impl Fn(&Token) -> bool + use<'_> {
     move |token| tokens.contains(&token.kind)
 }
 
-fn token_as_type<'a>(token: &'a Token) -> Result<ast::Type> {
+fn token_as_type<'a>(mut_token: Option<Token>, token: &'a Token) -> Result<ast::Type> {
     let parse_type = |input: &'a str| -> Option<(&'a str, &'a str)> {
         let (prefix, rest) = input.split_at(1);
         if prefix.chars().all(char::is_alphabetic) && rest.chars().all(char::is_numeric) {
@@ -760,12 +776,15 @@ fn token_as_type<'a>(token: &'a Token) -> Result<ast::Type> {
             return Ok(ast::Type {
                 kind: ast::TypeKind::Void,
                 span: token.span.clone(),
+                // Maybe this should be an error?
+                mut_token,
             });
         }
         "bool" => {
             return Ok(ast::Type {
                 kind: ast::TypeKind::Bool,
                 span: token.span.clone(),
+                mut_token,
             });
         }
         _ => (),
@@ -775,6 +794,7 @@ fn token_as_type<'a>(token: &'a Token) -> Result<ast::Type> {
             return Ok(ast::Type {
                 kind: ast::TypeKind::Name(token.lexeme.clone()),
                 span: token.span.clone(),
+                ..Default::default()
             });
         }
         return Err(Box::new(ErrorExpectedType {
@@ -785,22 +805,18 @@ fn token_as_type<'a>(token: &'a Token) -> Result<ast::Type> {
         "u" => Ok(ast::Type {
             kind: ast::TypeKind::UnsignedNumber(number.parse().unwrap()),
             span: token.span.clone(),
+            mut_token,
         }),
         "s" => Ok(ast::Type {
             kind: ast::TypeKind::SignedNumber(number.parse().unwrap()),
             span: token.span.clone(),
+            mut_token,
         }),
         "f" => Ok(ast::Type {
             kind: ast::TypeKind::Float(number.parse().unwrap()),
             span: token.span.clone(),
+            mut_token,
         }),
-        "*" => {
-            let ty = token_as_type(&Token::new(TokenKind::Number, number, token.span.clone()))?;
-            Ok(ast::Type {
-                kind: ast::TypeKind::Pointer(Box::new(ty)),
-                span: token.span.clone(),
-            })
-        }
         _ => Err(Box::new(ErrorExpectedType {
             found: token.clone(),
         })),

--- a/src/stage/semantic_analyzer/symbol_table.rs
+++ b/src/stage/semantic_analyzer/symbol_table.rs
@@ -98,6 +98,8 @@ impl SymbolTableBuilder {
             name: struct_def.name.lexeme.clone(),
             kind: SymbolKind::Struct,
             ty: ast::Type {
+                // We set None here cause we dont know if it is mutable at the call site.
+                mut_token: None,
                 kind: ast::TypeKind::Struct(ast::StructType {
                     name: struct_def.name.lexeme.clone(),
                     fields: struct_def
@@ -193,6 +195,7 @@ impl SymbolTableBuilder {
             ast::Type {
                 kind: ast::TypeKind::Void,
                 span: expr.span(),
+                ..Default::default()
             },
             |ty| ty.clone(),
         );
@@ -232,9 +235,8 @@ impl SymbolTableBuilder {
             return;
         }
 
-        self.errors.push(Box::new(ErrorUndefinedSymbol {
-            found: token.clone(),
-        }));
+        self.errors
+            .push(Box::new(ErrorUndefinedSymbol::Token(token.clone())));
     }
 
     fn walk_expr_if_else(&mut self, expr: &ast::ExprIfElse) {
@@ -475,7 +477,11 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn create_ty(kind: ast::TypeKind) -> ast::Type {
-        ast::Type { kind, span: 0..1 }
+        ast::Type {
+            kind,
+            span: 0..1,
+            ..Default::default()
+        }
     }
 
     fn create_symbol(
@@ -611,17 +617,20 @@ mod tests {
                 ty: ast::Type {
                     kind: ast::TypeKind::SignedNumber(32),
                     span: 32..35,
+                    ..Default::default()
                 },
                 is_mutable: false,
                 visibility: ast::Visibility::Private,
                 params: Some(vec![
                     ast::Type {
                         kind: ast::TypeKind::SignedNumber(32),
-                        span: 19..22
+                        span: 19..22,
+                        ..Default::default()
                     },
                     ast::Type {
                         kind: ast::TypeKind::SignedNumber(32),
-                        span: 27..30
+                        span: 27..30,
+                        ..Default::default()
                     },
                 ]),
                 ..Default::default()

--- a/src/stage/semantic_analyzer/type_check.rs
+++ b/src/stage/semantic_analyzer/type_check.rs
@@ -150,6 +150,7 @@ impl<'st> TypeChecker<'st> {
 
     fn walk_struct_def(&mut self, struct_def: &mut ast::Struct) -> ast::Type {
         Type {
+            mut_token: None,
             span: struct_def.span(),
             kind: TypeKind::Struct(StructType {
                 name: struct_def.name.lexeme.clone(),
@@ -167,6 +168,7 @@ impl<'st> TypeChecker<'st> {
         let mut last_type = Type {
             kind: TypeKind::Void,
             span: 0..1,
+            mut_token: None,
         };
 
         let last_index = block.statements.len().saturating_sub(1);
@@ -182,6 +184,7 @@ impl<'st> TypeChecker<'st> {
                 last_type = ty;
             } else if statement.delem.is_some() {
                 last_type = Type {
+                    mut_token: None,
                     kind: TypeKind::Void,
                     span: 0..1,
                 };
@@ -222,6 +225,7 @@ impl<'st> TypeChecker<'st> {
             return Type {
                 kind: TypeKind::Void,
                 span: expr.span(),
+                mut_token: None,
             };
         };
         self.walk_expr(expr)
@@ -286,14 +290,17 @@ impl<'st> TypeChecker<'st> {
             ast::Litral::Integer(_) => self.numeric_hint.clone().unwrap_or(Type {
                 kind: TypeKind::SignedNumber(32),
                 span: expr.span(),
+                mut_token: None,
             }),
             ast::Litral::Float(_) => self.numeric_hint.clone().unwrap_or(Type {
                 kind: TypeKind::Float(32),
                 span: expr.span(),
+                mut_token: None,
             }),
             ast::Litral::Char(_) => Type {
                 kind: TypeKind::UnsignedNumber(8),
                 span: expr.span(),
+                mut_token: None,
             },
             ast::Litral::String(s) => Type {
                 kind: TypeKind::Array(
@@ -301,13 +308,16 @@ impl<'st> TypeChecker<'st> {
                     Box::new(Type {
                         kind: TypeKind::UnsignedNumber(8),
                         span: expr.span(),
+                        mut_token: None,
                     }),
                 ),
                 span: expr.span(),
+                mut_token: None,
             },
             ast::Litral::BoolTrue(_) | ast::Litral::BoolFalse(_) => Type {
                 kind: TypeKind::Bool,
                 span: expr.span(),
+                mut_token: None,
             },
         }
     }
@@ -342,6 +352,7 @@ impl<'st> TypeChecker<'st> {
             return Type {
                 kind: TypeKind::Void,
                 span: left_ty.span,
+                mut_token: None,
             };
         };
         result_ty
@@ -349,12 +360,12 @@ impl<'st> TypeChecker<'st> {
 
     fn walk_expr_identifier(&mut self, expr: &Token) -> ast::Type {
         let Some(symbol) = self.symbol_table.get(expr.lexeme.as_str()) else {
-            self.errors.push(Box::new(ErrorUndefinedSymbol {
-                found: expr.clone(),
-            }));
+            self.errors
+                .push(Box::new(ErrorUndefinedSymbol::Token(expr.clone())));
             return Type {
                 kind: TypeKind::Void,
                 span: expr.span.clone(),
+                mut_token: None,
             };
         };
         symbol.ty.clone()
@@ -387,6 +398,7 @@ impl<'st> TypeChecker<'st> {
         Type {
             kind: TypeKind::Void,
             span: expr.span(),
+            mut_token: None,
         }
     }
 
@@ -408,6 +420,7 @@ impl<'st> TypeChecker<'st> {
         Type {
             kind: TypeKind::Array(size, Box::new(ty)),
             span: expr.span(),
+            mut_token: None,
         }
     }
     fn walk_expr_array_index(&mut self, expr: &mut ast::ExprArrayIndex) -> Type {
@@ -435,6 +448,7 @@ impl<'st> TypeChecker<'st> {
                     Box::new(Type {
                         kind: TypeKind::Void,
                         span: 0..1,
+                        mut_token: None,
                     }),
                 ),
                 #[cfg(feature = "debug")]
@@ -448,8 +462,9 @@ impl<'st> TypeChecker<'st> {
     fn walk_expr_address_of(&mut self, expr: &mut ast::ExprAddressOf) -> Type {
         let inner_type = self.walk_expr(&mut expr.expr);
         Type {
-            kind: TypeKind::Pointer(Box::new(inner_type)),
+            kind: TypeKind::Ref(Box::new(inner_type)),
             span: expr.span(),
+            mut_token: None,
         }
     }
 
@@ -458,6 +473,7 @@ impl<'st> TypeChecker<'st> {
         Type {
             kind: TypeKind::Bool,
             span: expr.span(),
+            mut_token: None,
         }
     }
 
@@ -481,6 +497,7 @@ impl<'st> TypeChecker<'st> {
                 Box::new(value_type.clone()),
             ),
             span: expr.span(),
+            mut_token: None,
         };
 
         expr.ty.clone()
@@ -515,12 +532,13 @@ impl<'st> TypeChecker<'st> {
                 Type {
                     kind: TypeKind::SignedNumber(32),
                     span: expr.span(),
+                    mut_token: None,
                 }
             }
             TypeKind::Struct(struct_def) => {
                 self.lookup_struct_member(&struct_def, &member_access.member.lexeme)
             }
-            TypeKind::Pointer(inner) => match &inner.kind {
+            TypeKind::Ref(inner) => match &inner.kind {
                 TypeKind::Struct(struct_def) => {
                     self.lookup_struct_member(struct_def, &member_access.member.lexeme)
                 }
@@ -536,24 +554,28 @@ impl<'st> TypeChecker<'st> {
                 self.numeric_hint = Some(Type {
                     kind: elem_ty.kind.clone(),
                     span: maybe.span.clone(),
+                    mut_token: None,
                 })
             }
             ty @ TypeKind::SignedNumber(_) => {
                 self.numeric_hint = Some(Type {
                     kind: ty.clone(),
                     span: maybe.span.clone(),
+                    mut_token: None,
                 })
             }
             ty @ TypeKind::UnsignedNumber(_) => {
                 self.numeric_hint = Some(Type {
                     kind: ty.clone(),
                     span: maybe.span.clone(),
+                    mut_token: None,
                 })
             }
             ty @ TypeKind::Float(_) => {
                 self.numeric_hint = Some(Type {
                     kind: ty.clone(),
                     span: maybe.span.clone(),
+                    mut_token: None,
                 })
             }
             _ => {}

--- a/src/stage/semantic_analyzer/type_resolver.rs
+++ b/src/stage/semantic_analyzer/type_resolver.rs
@@ -1,6 +1,8 @@
 #![allow(unused)]
 
-use crate::error::{ErrorMissMatchedType, ErrorUnsupportedBinaryOp, Errors, Report, Result};
+use crate::error::{
+    ErrorMissMatchedType, ErrorUndefinedSymbol, ErrorUnsupportedBinaryOp, Errors, Report, Result,
+};
 use crate::stage::lexer::token::Span;
 use crate::stage::parser::ast::{self, Expr, StructType, Type, TypeKind};
 use crate::stage::semantic_analyzer::symbol_table::SymbolTable;
@@ -222,7 +224,7 @@ impl<'st> TypeResolver<'st> {
             | TypeKind::Float(_)
             | TypeKind::Void => {}
             TypeKind::Array(_, ty) => self.walk_type(ty),
-            TypeKind::Pointer(ty) => self.walk_type(ty),
+            TypeKind::Ref(ty) => self.walk_type(ty),
             TypeKind::Struct(struct_type) => {
                 for (_, ty) in struct_type.fields.iter_mut() {
                     self.walk_type(ty);
@@ -231,12 +233,19 @@ impl<'st> TypeResolver<'st> {
             TypeKind::Enum(_) => todo!("Enum"),
             TypeKind::Name(name) => {
                 let Some(symbol) = self.symbol_table.get(name) else {
-                    self.errors.push(Box::new(ErrorMissMatchedType {
-                        found,
-                        expected: TypeKind::Name(name.clone()),
-                        #[cfg(feature = "debug")]
-                        compiler_line: format!("{} {}:{}", file!(), line!(), column!()),
-                    }));
+                    self.errors
+                        .push(Box::new(ErrorUndefinedSymbol::Type(found)));
+                    return;
+                };
+                *ty = symbol.ty.clone();
+            }
+            TypeKind::NameWithParams(name, params) => {
+                for param in params.params.iter_mut() {
+                    self.walk_type(param);
+                }
+                let Some(symbol) = self.symbol_table.get(&name.lexeme) else {
+                    self.errors
+                        .push(Box::new(ErrorUndefinedSymbol::Type(found)));
                     return;
                 };
                 *ty = symbol.ty.clone();


### PR DESCRIPTION
#21 
This PR aims to implement parsing generics in a functions signature.
`fn test(s: ref Slice(u8)) void { }`
