### PR TITLE
feat(backend): less than equals

### DIFF
--- a/bitbox/src/backend/bitbeat/passes/emit/emitter.rs
+++ b/bitbox/src/backend/bitbeat/passes/emit/emitter.rs
@@ -106,6 +106,7 @@ impl Lower<BitbeatLowerContext<'_>> for crate::ir::Instruction {
             crate::ir::Instruction::Gte(..) => todo!("gte"),
             crate::ir::Instruction::Rem(..) => todo!("rem"),
             crate::ir::Instruction::Lt(ilt) => ilt.lower(ctx, target)?,
+            crate::ir::Instruction::Lte(..) => todo!("lte"),
             crate::ir::Instruction::Jump(ijump) => ijump.lower(ctx, target)?,
             crate::ir::Instruction::JumpIf(ijumpif) => ijumpif.lower(ctx, target)?,
             crate::ir::Instruction::Load(iload) => iload.lower(ctx, target)?,

--- a/bitbox/src/backend/wasm32/passes/emit/instruction.rs
+++ b/bitbox/src/backend/wasm32/passes/emit/instruction.rs
@@ -5,7 +5,8 @@ use crate::backend::Lower;
 
 use crate::ir::instruction::{
     IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, ICopy, IDiv, IElemGet, IElemSet, IGt, IGte,
-    IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INot, IOr, IRef, IRem, IReturn, ISub, IXOr,
+    IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, ILte, IMul, INot, IOr, IRef, IRem, IReturn, ISub,
+    IXOr,
 };
 use crate::ir::{BasicBlock, Instruction, Type};
 
@@ -736,11 +737,41 @@ impl Lower<Wasm32LowerContext<'_>> for ILt {
         self.rhs.lower(ctx, target)?;
         match self.des.ty.clone().into() {
             ValType::I32 => target.assembler.i32_lt_s(),
-            ValType::I64 => todo!("@gt i64"),
-            ValType::F32 => todo!("@gt f32"),
-            ValType::F64 => todo!("@gt f64"),
-            ValType::V128 => todo!("@gt v128"),
-            ValType::Ref(_) => todo!("@gt ref"),
+            ValType::I64 => todo!("@lt i64"),
+            ValType::F32 => todo!("@lt f32"),
+            ValType::F64 => todo!("@lt f64"),
+            ValType::V128 => todo!("@lt v128"),
+            ValType::Ref(_) => todo!("@lt ref"),
+        };
+        let Some(idx) = ctx
+            .local_function_variables
+            .get(&target.function_name)
+            .iter()
+            .position(|v| v.name == self.des.name)
+        else {
+            panic!("Variable {:?} not found", self.des);
+        };
+        target.assembler.local_set(idx as u32);
+        Ok(())
+    }
+}
+
+impl Lower<Wasm32LowerContext<'_>> for ILte {
+    type Output = ();
+    fn lower(
+        &self,
+        ctx: &mut crate::backend::Context,
+        target: &mut Wasm32LowerContext<'_>,
+    ) -> Result<Self::Output, crate::error::Error> {
+        self.lhs.lower(ctx, target)?;
+        self.rhs.lower(ctx, target)?;
+        match self.des.ty.clone().into() {
+            ValType::I32 => target.assembler.i32_le_s(),
+            ValType::I64 => target.assembler.i64_le_s(),
+            ValType::F32 => target.assembler.f32_le(),
+            ValType::F64 => target.assembler.f64_le(),
+            ValType::V128 => todo!("@lte v128"),
+            ValType::Ref(_) => todo!("@lte ref"),
         };
         let Some(idx) = ctx
             .local_function_variables

--- a/bitbox/src/backend/wasm32/passes/emit/mod.rs
+++ b/bitbox/src/backend/wasm32/passes/emit/mod.rs
@@ -350,6 +350,7 @@ impl Lower<Wasm32LowerContext<'_>> for ir::Instruction {
             ir::Instruction::Gte(igte) => igte.lower(ctx, target)?,
             ir::Instruction::Rem(irem) => irem.lower(ctx, target)?,
             ir::Instruction::Lt(ilt) => ilt.lower(ctx, target)?,
+            ir::Instruction::Lte(..) => todo!("wasm lte"),
             ir::Instruction::Jump(ijump) => ijump.lower(ctx, target)?,
             ir::Instruction::JumpIf(ijumpif) => ijumpif.lower(ctx, target)?,
             ir::Instruction::Load(iload) => iload.lower(ctx, target)?,

--- a/bitbox/src/backend/wasm32/passes/emit/mod.rs
+++ b/bitbox/src/backend/wasm32/passes/emit/mod.rs
@@ -350,7 +350,7 @@ impl Lower<Wasm32LowerContext<'_>> for ir::Instruction {
             ir::Instruction::Gte(igte) => igte.lower(ctx, target)?,
             ir::Instruction::Rem(irem) => irem.lower(ctx, target)?,
             ir::Instruction::Lt(ilt) => ilt.lower(ctx, target)?,
-            ir::Instruction::Lte(..) => todo!("wasm lte"),
+            ir::Instruction::Lte(ilte) => ilte.lower(ctx, target)?,
             ir::Instruction::Jump(ijump) => ijump.lower(ctx, target)?,
             ir::Instruction::JumpIf(ijumpif) => ijumpif.lower(ctx, target)?,
             ir::Instruction::Load(iload) => iload.lower(ctx, target)?,

--- a/bitbox/src/backend/x86_64/linux/passes/emit/assembler/mod.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/assembler/mod.rs
@@ -237,6 +237,7 @@ pub enum Instruction {
     Setg(Location),
     Setge(Location),
     Setl(Location),
+    Setle(Location),
     Seta(Location),
     Setae(Location),
     Setb(Location),
@@ -304,6 +305,7 @@ impl std::fmt::Display for Instruction {
             Self::Setg(dst) => write!(f, "  setg {dst}"),
             Self::Setge(dst) => write!(f, "  setge {dst}"),
             Self::Setl(dst) => write!(f, "  setl {dst}"),
+            Self::Setle(dst) => write!(f, "  setle {dst}"),
             Self::Seta(dst) => write!(f, "  seta {dst}"),
             Self::Setae(dst) => write!(f, "  setae {dst}"),
             Self::Setb(dst) => write!(f, "  setb {dst}"),
@@ -764,6 +766,13 @@ impl Assembler {
         let src = src.into();
         debug_assert!(!matches!(src, Location::Imm(_)));
         self.push_to(self.current_section, Instruction::Setl(src));
+        self
+    }
+
+    pub fn setle(&mut self, src: impl Into<Location>) -> &mut Self {
+        let src = src.into();
+        debug_assert!(!matches!(src, Location::Imm(_)));
+        self.push_to(self.current_section, Instruction::Setle(src));
         self
     }
 

--- a/bitbox/src/backend/x86_64/linux/passes/emit/instruction.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/instruction.rs
@@ -7,7 +7,7 @@ use crate::backend::x86_64::linux::passes::emit::assembler::{
 use crate::backend::x86_64::linux::passes::emit::error::Error;
 use crate::ir::instruction::{
     CastKind, IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, IDiv, IElemGet, IElemSet, IGt, IGte,
-    IJump, IJumpIf, ILt, IMul, INot, IRef, IRem, IReturn, ISub,
+    IJump, IJumpIf, ILt, ILte, IMul, INot, IRef, IRem, IReturn, ISub,
 };
 use crate::ir::{AbiChunk, Operand, Type};
 
@@ -527,6 +527,42 @@ impl Lower<X86_64LinuxLowerContext<'_>> for ILt {
             _ => {
                 target.assembler.cmp(lhs.clone(), rhs.clone());
                 target.assembler.setl(flag);
+            }
+        }
+        target.assembler.movezx(out, flag);
+        target.assembler.alloc.store_variable(&self.des, out);
+        Ok(())
+    }
+}
+
+impl Lower<X86_64LinuxLowerContext<'_>> for ILte {
+    type Output = ();
+    fn lower(
+        &self,
+        ctx: &mut crate::backend::Context,
+        target: &mut X86_64LinuxLowerContext<'_>,
+    ) -> Result<Self::Output, crate::error::Error> {
+        target.assembler.comment("lowering lt");
+        let lhs = self.lhs.lower(ctx, target)?;
+        let rhs = self.rhs.lower(ctx, target)?;
+        let flag = target.assembler.alloc.vreg::<Reg8>();
+        let out = target.assembler.alloc.vreg::<Reg64>();
+        match self.lhs.ty() {
+            Some(Type::Float(32)) => {
+                let lhs_xmm = target.assembler.alloc.vreg::<XmmReg>();
+                target.assembler.movss(Location::Reg(lhs_xmm), lhs);
+                target.assembler.ucomiss(Location::Reg(lhs_xmm), rhs);
+                target.assembler.setb(flag);
+            }
+            Some(Type::Float(64)) => {
+                let lhs_xmm = target.assembler.alloc.vreg::<XmmReg>();
+                target.assembler.movsd(Location::Reg(lhs_xmm), lhs);
+                target.assembler.ucomisd(Location::Reg(lhs_xmm), rhs);
+                target.assembler.setb(flag);
+            }
+            _ => {
+                target.assembler.cmp(lhs.clone(), rhs.clone());
+                target.assembler.setle(flag);
             }
         }
         target.assembler.movezx(out, flag);

--- a/bitbox/src/backend/x86_64/linux/passes/emit/mod.rs
+++ b/bitbox/src/backend/x86_64/linux/passes/emit/mod.rs
@@ -320,6 +320,7 @@ impl Lower<X86_64LinuxLowerContext<'_>> for ir::Instruction {
             ir::Instruction::JumpIf(ijump) => ijump.lower(ctx, target)?,
             ir::Instruction::Load(..) => todo!("load"),
             ir::Instruction::Lt(ilt) => ilt.lower(ctx, target)?,
+            ir::Instruction::Lte(ilte) => ilte.lower(ctx, target)?,
             ir::Instruction::Mul(imul) => imul.lower(ctx, target)?,
             ir::Instruction::NoOp(..) => todo!(),
             ir::Instruction::Or(..) => todo!("or"),

--- a/bitbox/src/ir/builder.rs
+++ b/bitbox/src/ir/builder.rs
@@ -3,8 +3,8 @@ use crate::ir::{
     Type, Variable, Visibility,
     instruction::{
         CastKind, IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, IDiv, IElemGet, IElemSet, IGt,
-        IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef, IRem,
-        IReturn, ISub, IXOr, Label,
+        IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, ILte, IMul, INoOp, INot, IOr, IPhi, IRef,
+        IRem, IReturn, ISub, IXOr, Label,
     },
 };
 
@@ -339,6 +339,14 @@ impl<'a> AssemblerBuilder<'a> {
         let lhs = lhs.into();
         let rhs = rhs.into();
         self.push_instruction(ILt::new(des, lhs, rhs));
+        self
+    }
+
+    /// `@lte <type> : <des>, <lhs>, <rhs>`
+    pub fn lte(&mut self, des: Variable, lhs: Variable, rhs: Variable) -> &mut Self {
+        let lhs = lhs.into();
+        let rhs = rhs.into();
+        self.push_instruction(ILte::new(des, lhs, rhs));
         self
     }
 

--- a/bitbox/src/ir/instruction.rs
+++ b/bitbox/src/ir/instruction.rs
@@ -45,6 +45,9 @@ pub enum Instruction {
     /// `@lt <type> : <des>, <lhs>, <rhs>`
     /// `@lt u1 : is_one, n, 1`
     Lt(ILt),
+    /// `@lte <type> : <des>, <lhs>, <rhs>`
+    /// `@lte u1 : is_one, n, 1`
+    Lte(ILte),
     /// @jump <label>
     /// @jump %recursive_case
     Jump(IJump),
@@ -101,6 +104,7 @@ impl fmt::Display for Instruction {
             Self::Gte(igte) => write!(f, "{igte}"),
             Self::Rem(irem) => write!(f, "{irem}"),
             Self::Lt(ilt) => write!(f, "{ilt}"),
+            Self::Lte(ilte) => write!(f, "{ilte}"),
             Self::Assign(iassign) => write!(f, "{iassign}"),
             Self::Alloc(ialloc) => write!(f, "{ialloc}"),
             Self::Call(icall) => write!(f, "{icall}"),
@@ -284,6 +288,15 @@ create_binary_instruction!(
     ILt,
     Lt,
     "lt"
+);
+create_binary_instruction!(
+    "`@lte <type> : <des>, <lhs>, <rhs>`
+
+`@lte u1 : is_one, n, 1`
+",
+    ILte,
+    Lte,
+    "lte"
 );
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/bitbox/src/passes/liveness.rs
+++ b/bitbox/src/passes/liveness.rs
@@ -3,8 +3,8 @@ use crate::{
         BasicBlock, BlockId, Instruction, Variable,
         instruction::{
             IAdd, IAlloc, IAnd, IAssign, ICall, ICast, ICmp, ICopy, IDiv, IElemGet, IElemSet, IGt,
-            IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, IMul, INoOp, INot, IOr, IPhi, IRef,
-            IRem, IReturn, ISub, IXOr,
+            IGte, IIfElse, IJump, IJumpIf, ILoad, ILoop, ILt, ILte, IMul, INoOp, INot, IOr, IPhi,
+            IRef, IRem, IReturn, ISub, IXOr,
         },
     },
     passes::{DebugPass, PassOutput},
@@ -42,7 +42,7 @@ macro_rules! liveness_ops {
 }
 
 liveness_ops!(
-    IAdd, ISub, IMul, IDiv, ICmp, IGt, IGte, IRem, ILt, IAnd, IOr, IXOr
+    IAdd, ISub, IMul, IDiv, ICmp, IGt, IGte, IRem, ILt, ILte, IAnd, IOr, IXOr
 );
 
 impl LivenessAnalysis for IAssign {
@@ -335,6 +335,7 @@ impl crate::ir::Instruction {
             Self::Gte(i) => i.uses(),
             Self::Rem(i) => i.uses(),
             Self::Lt(i) => i.uses(),
+            Self::Lte(i) => i.uses(),
             Self::Jump(i) => i.uses(),
             Self::JumpIf(i) => i.uses(),
             Self::Load(i) => i.uses(),
@@ -369,6 +370,7 @@ impl crate::ir::Instruction {
             Self::Gte(i) => i.defines(),
             Self::Rem(i) => i.defines(),
             Self::Lt(i) => i.defines(),
+            Self::Lte(i) => i.defines(),
             Self::Jump(i) => i.defines(),
             Self::JumpIf(i) => i.defines(),
             Self::Load(i) => i.defines(),

--- a/bitbox/src/passes/local_function_variables.rs
+++ b/bitbox/src/passes/local_function_variables.rs
@@ -150,6 +150,9 @@ fn block_pass(
             crate::ir::Instruction::Lt(ilt) => ctx
                 .local_function_variables
                 .add(function_name, ilt.des.clone()),
+            crate::ir::Instruction::Lte(ilte) => ctx
+                .local_function_variables
+                .add(function_name, ilte.des.clone()),
             crate::ir::Instruction::Load(iload) => ctx
                 .local_function_variables
                 .add(function_name, iload.des.clone()),

--- a/src/stage/ir_builder/mod.rs
+++ b/src/stage/ir_builder/mod.rs
@@ -365,6 +365,7 @@ impl Lowerable for ExprBinary {
             TokenKind::Less => assembler.lt(des.clone(), lhs, rhs),
             TokenKind::EqualEqual => assembler.eq(des.clone(), lhs, rhs),
             TokenKind::GreaterEqual => assembler.gte(des.clone(), lhs, rhs),
+            TokenKind::LessEqual => assembler.lte(des.clone(), lhs, rhs),
             TokenKind::Keyword(Keyword::And) => assembler.and(des.clone(), lhs, rhs),
             TokenKind::Keyword(Keyword::Or) => assembler.or(des.clone(), lhs, rhs),
             TokenKind::Percent => assembler.rem(des.clone(), lhs, rhs),


### PR DESCRIPTION
The PR implements `<=` for wasm and x86_64-linux back ends.  We are skipping the bitbeat backend do to its probably not going to make it to the boot strapped version.